### PR TITLE
 add comment Receiver class to trigger CommentService#deleteByPostId

### DIFF
--- a/src/main/java/com/example/commentsapi/mq/Receiver.java
+++ b/src/main/java/com/example/commentsapi/mq/Receiver.java
@@ -1,15 +1,20 @@
 package com.example.commentsapi.mq;
 
+import com.example.commentsapi.service.CommentServiceImpl;
 import org.springframework.amqp.rabbit.annotation.RabbitHandler;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 @RabbitListener(queues = "queue1")
 public class Receiver {
+    @Autowired
+    CommentServiceImpl commentService;
 
     @RabbitHandler
     public void receive(String msg) throws InterruptedException {
-        System.out.println("message received: " + msg);
+        System.out.println("post id: " + msg + " deleted.  Purging comments for post");
+        commentService.deleteByPostId(Integer.parseInt(msg));
     }
 }


### PR DESCRIPTION
RabbitMQ receiver class
 - consumes from queue1.
   - assuming messages in queue1 are from only one sender, should be just a String postId
   - tested manually through postman and is a cascade delete without relations