### PR TITLE
add exception handling for empty comment.text with new EmptyInputException.class

### DIFF
--- a/src/main/java/com/example/commentsapi/controller/CommentsApiController.java
+++ b/src/main/java/com/example/commentsapi/controller/CommentsApiController.java
@@ -1,5 +1,6 @@
 package com.example.commentsapi.controller;
 
+import com.example.commentsapi.exception.EmptyInputException;
 import com.example.commentsapi.model.Comment;
 import com.example.commentsapi.service.CommentServiceImpl;
 import io.swagger.annotations.*;
@@ -19,7 +20,7 @@ public class CommentsApiController {
             @ApiResponse(code = 201, message = "Successfully created a Comment")
     })
     @PostMapping("/{postId}")
-    public Comment createComment(@ApiParam(value="postId", required=true) @RequestBody Comment comment, @PathVariable int postId, @RequestHeader("userId") int userId, @RequestHeader("username") String username) {
+    public Comment createComment(@ApiParam(value="postId", required=true) @RequestBody Comment comment, @PathVariable int postId, @RequestHeader("userId") int userId, @RequestHeader("username") String username) throws EmptyInputException {
         return commentService.createComment(comment, postId, userId, username);
     }
 

--- a/src/main/java/com/example/commentsapi/exception/EmptyInputException.java
+++ b/src/main/java/com/example/commentsapi/exception/EmptyInputException.java
@@ -1,0 +1,9 @@
+package com.example.commentsapi.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class EmptyInputException extends Exception {
+    public EmptyInputException(HttpStatus notFound, String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/commentsapi/service/CommentService.java
+++ b/src/main/java/com/example/commentsapi/service/CommentService.java
@@ -1,12 +1,13 @@
 package com.example.commentsapi.service;
 
+import com.example.commentsapi.exception.EmptyInputException;
 import com.example.commentsapi.model.Comment;
 
 import javax.persistence.EntityNotFoundException;
 
 public interface CommentService {
 
-    public Comment createComment(Comment comment, int postId, int userId, String username) throws EntityNotFoundException;
+    public Comment createComment(Comment comment, int postId, int userId, String username) throws EntityNotFoundException, EmptyInputException;
 
     public Iterable<Comment> listCommentsByPostId(int postId);
 

--- a/src/main/java/com/example/commentsapi/service/CommentServiceImpl.java
+++ b/src/main/java/com/example/commentsapi/service/CommentServiceImpl.java
@@ -2,11 +2,13 @@ package com.example.commentsapi.service;
 
 import com.example.commentsapi.bean.PostBean;
 import com.example.commentsapi.bean.UserBean;
+import com.example.commentsapi.exception.EmptyInputException;
 import com.example.commentsapi.feign.PostClient;
 import com.example.commentsapi.feign.UserClient;
 import com.example.commentsapi.model.Comment;
 import com.example.commentsapi.repository.CommentRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 import javax.persistence.EntityNotFoundException;
@@ -26,12 +28,15 @@ public class CommentServiceImpl implements CommentService {
     private PostClient postClient;
 
     @Override
-    public Comment createComment(Comment comment, int postId, int userId, String username) throws EntityNotFoundException {
-        // TODO: add missing post case
+    public Comment createComment(Comment comment, int postId, int userId, String username) throws EntityNotFoundException, EmptyInputException {
         PostBean targetPost = postClient.getPostById(postId);
         UserBean targetUser = userClient.getUserById(userId);
         if(targetPost == null) {
             throw new EntityNotFoundException("Post does not exist");
+        }
+
+        if(comment.getText().trim() == "") {
+            throw new EmptyInputException(HttpStatus.BAD_REQUEST,"Comment text cannot be blank");
         }
 
         HashMap<String, String> usernameMap = new HashMap<>();

--- a/src/test/java/com/example/commentsapi/service/CommentServiceTest.java
+++ b/src/test/java/com/example/commentsapi/service/CommentServiceTest.java
@@ -2,6 +2,7 @@ package com.example.commentsapi.service;
 
 import com.example.commentsapi.bean.PostBean;
 import com.example.commentsapi.bean.UserBean;
+import com.example.commentsapi.exception.EmptyInputException;
 import com.example.commentsapi.feign.PostClient;
 import com.example.commentsapi.feign.UserClient;
 import com.example.commentsapi.model.Comment;
@@ -60,7 +61,7 @@ public class CommentServiceTest {
     }
 
     @Test
-    public void createComment_Comment_Success() {
+    public void createComment_Comment_Success() throws EmptyInputException {
         when(userClient.getUserById(anyInt())).thenReturn(tempUser);
         when(postClient.getPostById(anyInt())).thenReturn(tempPost);
         when(commentRepository.save(any())).thenReturn(tempComment);
@@ -73,7 +74,7 @@ public class CommentServiceTest {
     }
 
     @Test(expected = EntityNotFoundException.class)
-    public void createComment_Comment_Failure() {
+    public void createComment_Comment_Failure() throws EmptyInputException {
         when(postClient.getPostById(anyInt())).thenReturn(null);
         Comment failedComment = commentService.createComment(tempComment, tempPost.getId(), tempUser.getId(), tempUser.getUsername());
     }
@@ -102,8 +103,7 @@ public class CommentServiceTest {
         when(commentRepository.findAll()).thenReturn(commentList);
         when(userClient.getUserById(anyInt())).thenReturn(tempUser);
         when(postClient.getPostById(anyInt())).thenReturn(tempPost);
-//
-//        verify(commentRepository, times(1)).purgeComments(eq(1));
+
         verify(userClient, times(1)).getUserById(tempComment.getUserId());
         verify(postClient, times(1)).getPostById(tempComment.getPostId());
 


### PR DESCRIPTION
Adds the following:
 - Create New Exception: EmptyInputException
   - Triggered by CommentServiceImpl#createComment where newComment object has an "empty" text.  Ie trimmed white space.

Note: all front ends handle this differently, which is good and bad i guess.